### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-
+from urllib.parse import urlparse
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -149,7 +149,7 @@ def test_oauth_authorization_url(auth_enabled, mock_oauth_flow):
     assert resp.status_code == 200  # Returns JSON with authorization URL
     data = resp.json()
     assert "authorization_url" in data
-    assert "accounts.google.com" in data["authorization_url"]
+    assert urlparse(data["authorization_url"]).hostname == "accounts.google.com"
 
 
 def test_jwt_login_endpoint(auth_enabled):


### PR DESCRIPTION
Potential fix for [https://github.com/tuandzung/heimdall/security/code-scanning/1](https://github.com/tuandzung/heimdall/security/code-scanning/1)

The best way to fix the problem is to parse the URL and explicitly check if the host matches `accounts.google.com`, instead of just looking for the substring "accounts.google.com" anywhere in the URL. In the context of this test, we want to validate that the returned authorization URL actually points to the correct OAuth domain. This can be done by using Python's `urllib.parse` to extract and compare the hostname of the returned URL. The fix should occur in `test_oauth_authorization_url`, where line 152 currently performs an unsafe substring check. We should import `urlparse` (from `urllib.parse`) at the top if it’s not already imported, then parse `data["authorization_url"]`, and assert that its `hostname` equals `accounts.google.com`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
